### PR TITLE
Add the alias command

### DIFF
--- a/Import.php
+++ b/Import.php
@@ -19,6 +19,7 @@ spl_autoload_register(function ($class) {
         'Saeghe\Saeghe\Classes\Config\LinkPair' => realpath(__DIR__ . '/Source/Classes/Config/LinkPair.php'),
         'Saeghe\Saeghe\Classes\Config\NamespaceFilePair' => realpath(__DIR__ . '/Source/Classes/Config/NamespaceFilePair.php'),
         'Saeghe\Saeghe\Classes\Config\NamespacePathPair' => realpath(__DIR__ . '/Source/Classes/Config/NamespacePathPair.php'),
+        'Saeghe\Saeghe\Classes\Config\PackageAlias' => realpath(__DIR__ . '/Source/Classes/Config/PackageAlias.php'),
         'Saeghe\Saeghe\Classes\Credential\Credential' => realpath(__DIR__ . '/Source/Classes/Credential/Credential.php'),
         'Saeghe\Saeghe\Classes\Credential\Credentials' => realpath(__DIR__ . '/Source/Classes/Credential/Credentials.php'),
         'Saeghe\Saeghe\Classes\Environment\Environment' => realpath(__DIR__ . '/Source/Classes/Environment/Environment.php'),

--- a/Source/Classes/Config/PackageAlias.php
+++ b/Source/Classes/Config/PackageAlias.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Saeghe\Saeghe\Classes\Config;
+
+use Saeghe\Datatype\Pair;
+
+class PackageAlias extends Pair
+{
+    public function alias(): string
+    {
+        return $this->key;
+    }
+
+    public function package_url(): string
+    {
+        return $this->value;
+    }
+}

--- a/Source/Commands/Alias.php
+++ b/Source/Commands/Alias.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Saeghe\Saeghe\Commands\Alias;
+
+use Saeghe\FileManager\FileType\Json;
+use Saeghe\Saeghe\Classes\Config\PackageAlias;
+use Saeghe\Saeghe\Classes\Config\Config;
+use Saeghe\Saeghe\Classes\Environment\Environment;
+use Saeghe\Saeghe\Classes\Project\Project;
+use function Saeghe\Cli\IO\Read\argument;
+use function Saeghe\Cli\IO\Read\parameter;
+use function Saeghe\Cli\IO\Write\error;
+use function Saeghe\Cli\IO\Write\line;
+use function Saeghe\Cli\IO\Write\success;
+
+function run(Environment $environment): void
+{
+    $alias = argument(2);
+    $package_url = argument(3);
+
+    line("Registering alias $alias for $package_url...");
+
+    $project = new Project($environment->pwd->subdirectory(parameter('project', '')));
+
+    if (! $project->config_file->exists()) {
+        error('Project is not initialized. Please try to initialize using the init command.');
+        return;
+    }
+
+    $project->config(Config::from_array(Json\to_array($project->config_file)));
+
+    $registered_alias = $project->config->aliases->first(fn (PackageAlias $package_alias) => $package_alias->alias() === $alias);
+
+    if ($registered_alias) {
+        error("The alias is already registered for $registered_alias->value.");
+        return;
+    }
+
+    $project->config->aliases->push(new PackageAlias($alias, $package_url));
+
+    Json\write($project->config_file, $project->config->to_array());
+
+    success("Alias $alias has been registered for $package_url.");
+}

--- a/Source/Commands/Help.php
+++ b/Source/Commands/Help.php
@@ -17,7 +17,8 @@ start a working area
     migrate             Migrate from a composer project
 
 work with packages
-    credential          Add credential for given provider 
+    credential          Add credential for given provider
+    alias               Define an alias for a package 
     add                 Add a git repository as a package
     remove              Remove a git repository from packages
     update              Update the version of given package

--- a/Source/Commands/Man.php
+++ b/Source/Commands/Man.php
@@ -18,11 +18,15 @@ start a working area
                     `packages-directory` as an option. If passed, then your packages will be added under the given
                     directory instead of the default `Packages` directory.
     migrate  
-                    Migrate from a Composer project to a Saeghe project.
+                    Migrates from a Composer project to a Saeghe project.
 
 work with packages
     credential <provider> <token>
                     Add given `token` for the given `provider` in credential file.
+    alias <alias> <package>
+                    Defines the given alias as an alias for the given package. After defining an alias, you can use the
+                    alias in other commands where a package URL is required.
+
     add <package> {--version=}
                     Adds the given package to your project. This command needs a required `package` argument. You can 
                     pass an optional `version` option, then Saeghe will add the given version of the given package, 

--- a/Source/Commands/Version.php
+++ b/Source/Commands/Version.php
@@ -6,5 +6,5 @@ use Saeghe\Cli\IO\Write;
 
 function run(): void
 {
-    Write\success('Saeghe version 1.12.0');
+    Write\success('Saeghe version 1.13.0');
 }

--- a/Tests/System/AliasCommand/AddUsingAliasTest.php
+++ b/Tests/System/AliasCommand/AddUsingAliasTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\System\AliasCommand\AddUsingAliasTest;
+
+use function Saeghe\FileManager\Directory\clean;
+use function Saeghe\FileManager\Resolver\realpath;
+use function Saeghe\FileManager\Resolver\root;
+use function Saeghe\TestRunner\Assertions\Boolean\assert_true;
+
+test(
+    title: 'it should add package using alias',
+    case: function () {
+        $output = shell_exec('php ' . root() . 'saeghe add test-runner --project=TestRequirements/Fixtures/EmptyProject');
+
+        $expected = <<<EOD
+\e[39mAdding package test-runner latest version...
+\e[39mSetting env credential...
+\e[39mLoading configs...
+\e[39mChecking installed packages...
+\e[39mSetting package version...
+\e[39mCreating package directory...
+\e[39mDetecting version hash...
+\e[39mValidating the package...
+\e[39mDownloading the package...
+\e[39mUpdating configs...
+\e[39mCommitting configs...
+\e[92mPackage git@github.com:saeghe/test-runner.git has been added successfully.\e[39m
+
+EOD;
+
+        assert_true($expected === $output, 'Output is not correct:' . PHP_EOL . $expected . PHP_EOL . $output);
+        assert_true(file_exists(root() .  'TestRequirements/Fixtures/EmptyProject/Packages/saeghe/test-runner'));
+        assert_true(file_exists(root() .  'TestRequirements/Fixtures/EmptyProject/Packages/saeghe/test-runner/saeghe.config.json'));
+    },
+    before: function () {
+        shell_exec('php ' . root() . 'saeghe init --project=TestRequirements/Fixtures/EmptyProject');
+        shell_exec('php ' . root() . 'saeghe alias test-runner git@github.com:saeghe/test-runner.git --project=TestRequirements/Fixtures/EmptyProject');
+    },
+    after: function () {
+        clean(realpath(root() . 'TestRequirements/Fixtures/EmptyProject'));
+    }
+);

--- a/Tests/System/AliasCommand/AliasCommandTest.php
+++ b/Tests/System/AliasCommand/AliasCommandTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\System\AliasCommand\AliasCommandTest;
+
+use function Saeghe\FileManager\Directory\clean;
+use function Saeghe\FileManager\FileType\Json\to_array;
+use function Saeghe\FileManager\Resolver\realpath;
+use function Saeghe\FileManager\Resolver\root;
+use function Saeghe\TestRunner\Assertions\Boolean\assert_false;
+use function Saeghe\TestRunner\Assertions\Boolean\assert_true;
+
+test(
+    title: 'it should add the given alias to the config file',
+    case: function () {
+        $output = shell_exec('php ' . root() . 'saeghe alias test-runner git@github.com:saeghe/test-runner.git --project=TestRequirements/Fixtures/EmptyProject');
+
+        $expected = <<<EOD
+\e[39mRegistering alias test-runner for git@github.com:saeghe/test-runner.git...
+\e[92mAlias test-runner has been registered for git@github.com:saeghe/test-runner.git.\e[39m
+
+EOD;
+        assert_true($expected === $output, 'Output is not correct:' . PHP_EOL . $expected . PHP_EOL . $output);
+
+        $config = to_array(root() . 'TestRequirements/Fixtures/EmptyProject/saeghe.config.json');
+
+        assert_true(isset($config['aliases']['test-runner']) && $config['aliases']['test-runner'] === 'git@github.com:saeghe/test-runner.git');
+    },
+    before: function () {
+        shell_exec('php ' . root() . 'saeghe init --project=TestRequirements/Fixtures/EmptyProject');
+    },
+    after: function () {
+        clean(realpath(root() . 'TestRequirements/Fixtures/EmptyProject'));
+    }
+);
+
+test(
+    title: 'it should show error message when the project is not initialized',
+    case: function () {
+        $output = shell_exec('php ' . root() . 'saeghe alias test-runner git@github.com:saeghe/test-runner.git --project=TestRequirements/Fixtures/EmptyProject');
+        $expected = <<<EOD
+\e[39mRegistering alias test-runner for git@github.com:saeghe/test-runner.git...
+\e[91mProject is not initialized. Please try to initialize using the init command.\e[39m
+
+EOD;
+        assert_true($expected === $output, 'Output is not correct:' . PHP_EOL . $expected . PHP_EOL . $output);
+
+        assert_false(file_exists(root() . 'TestRequirements/Fixtures/EmptyProject/saeghe.config.json'));
+    }
+);
+
+test(
+    title: 'it should show error message when alias is registered',
+    case: function () {
+        $output = shell_exec('php ' . root() . 'saeghe alias test-runner git@github.com:saeghe/test-runner.git --project=TestRequirements/Fixtures/EmptyProject');
+
+        $expected = <<<EOD
+\e[39mRegistering alias test-runner for git@github.com:saeghe/test-runner.git...
+\e[91mThe alias is already registered for git@github.com:saeghe/test-runner.git.\e[39m
+
+EOD;
+        assert_true($expected === $output, 'Output is not correct:' . PHP_EOL . $expected . PHP_EOL . $output);
+
+        $config = to_array(root() . 'TestRequirements/Fixtures/EmptyProject/saeghe.config.json');
+
+        assert_true(isset($config['aliases']['test-runner']) && $config['aliases']['test-runner'] === 'git@github.com:saeghe/test-runner.git');
+    },
+    before: function () {
+        shell_exec('php ' . root() . 'saeghe init --project=TestRequirements/Fixtures/EmptyProject');
+        shell_exec('php ' . root() . 'saeghe alias test-runner git@github.com:saeghe/test-runner.git --project=TestRequirements/Fixtures/EmptyProject');
+    },
+    after: function () {
+        clean(realpath(root() . 'TestRequirements/Fixtures/EmptyProject'));
+    }
+);
+
+test(
+    title: 'it should show error message when alias is registered for other package',
+    case: function () {
+        $output = shell_exec('php ' . root() . 'saeghe alias test-runner git@github.com:saeghe/test-runner.git --project=TestRequirements/Fixtures/EmptyProject');
+
+        $expected = <<<EOD
+\e[39mRegistering alias test-runner for git@github.com:saeghe/test-runner.git...
+\e[91mThe alias is already registered for git@github.com:saeghe/cli.git.\e[39m
+
+EOD;
+        assert_true($expected === $output, 'Output is not correct:' . PHP_EOL . $expected . PHP_EOL . $output);
+
+        $config = to_array(root() . 'TestRequirements/Fixtures/EmptyProject/saeghe.config.json');
+
+        assert_true($config['aliases']['test-runner'] === 'git@github.com:saeghe/cli.git');
+    },
+    before: function () {
+        shell_exec('php ' . root() . 'saeghe init --project=TestRequirements/Fixtures/EmptyProject');
+        shell_exec('php ' . root() . 'saeghe alias test-runner git@github.com:saeghe/cli.git --project=TestRequirements/Fixtures/EmptyProject');
+    },
+    after: function () {
+        clean(realpath(root() . 'TestRequirements/Fixtures/EmptyProject'));
+    }
+);
+
+test(
+    title: 'it should show error message when alias is registered with different url',
+    case: function () {
+        $output = shell_exec('php ' . root() . 'saeghe alias test-runner https://github.com/saeghe/test-runner.git --project=TestRequirements/Fixtures/EmptyProject');
+
+        $expected = <<<EOD
+\e[39mRegistering alias test-runner for https://github.com/saeghe/test-runner.git...
+\e[91mThe alias is already registered for git@github.com:saeghe/test-runner.git.\e[39m
+
+EOD;
+        assert_true($expected === $output, 'Output is not correct:' . PHP_EOL . $expected . PHP_EOL . $output);
+
+        $config = to_array(root() . 'TestRequirements/Fixtures/EmptyProject/saeghe.config.json');
+
+        assert_true(isset($config['aliases']['test-runner']) && $config['aliases']['test-runner'] === 'git@github.com:saeghe/test-runner.git');
+    },
+    before: function () {
+        shell_exec('php ' . root() . 'saeghe init --project=TestRequirements/Fixtures/EmptyProject');
+        shell_exec('php ' . root() . 'saeghe alias test-runner git@github.com:saeghe/test-runner.git --project=TestRequirements/Fixtures/EmptyProject');
+    },
+    after: function () {
+        clean(realpath(root() . 'TestRequirements/Fixtures/EmptyProject'));
+    }
+);

--- a/Tests/System/AliasCommand/RemoveUsingAliasTest.php
+++ b/Tests/System/AliasCommand/RemoveUsingAliasTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\System\AliasCommand\RemoveUsingAliasTest;
+
+use function Saeghe\FileManager\Directory\clean;
+use function Saeghe\FileManager\Resolver\realpath;
+use function Saeghe\FileManager\Resolver\root;
+use function Saeghe\TestRunner\Assertions\Boolean\assert_false;
+use function Saeghe\TestRunner\Assertions\Boolean\assert_true;
+
+test(
+    title: 'it should remove package using alias',
+    case: function () {
+        $output = shell_exec('php ' . root() . 'saeghe remove datatype --project=TestRequirements/Fixtures/EmptyProject');
+        $expected = <<<EOD
+\e[39mRemoving package datatype
+\e[39mLoading configs...
+\e[39mFinding package in configs...
+\e[39mLoading package's config...
+\e[39mRemoving package from config...
+\e[39mCommitting configs...
+\e[92mPackage git@github.com:saeghe/datatype.git has been removed successfully.\e[39m
+
+EOD;
+
+        assert_true($expected === $output, 'Output is not correct:' . PHP_EOL . $expected . PHP_EOL . $output);
+        assert_false(file_exists(root() .  'TestRequirements/Fixtures/EmptyProject/Packages/saeghe/datatype'));
+    },
+    before: function () {
+        shell_exec('php ' . root() . 'saeghe init --project=TestRequirements/Fixtures/EmptyProject');
+        shell_exec('php ' . root() . 'saeghe alias datatype git@github.com:saeghe/datatype.git --project=TestRequirements/Fixtures/EmptyProject');
+        shell_exec('php ' . root() . 'saeghe add datatype --project=TestRequirements/Fixtures/EmptyProject');
+    },
+    after: function () {
+        clean(realpath(root() . 'TestRequirements/Fixtures/EmptyProject'));
+    }
+);

--- a/Tests/System/AliasCommand/UpdateUsingAliasTest.php
+++ b/Tests/System/AliasCommand/UpdateUsingAliasTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\System\AliasCommand\UpdateUsingAliasTest;
+
+use function Saeghe\FileManager\Directory\clean;
+use function Saeghe\FileManager\FileType\Json\to_array;
+use function Saeghe\FileManager\Resolver\realpath;
+use function Saeghe\FileManager\Resolver\root;
+use function Saeghe\TestRunner\Assertions\Boolean\assert_false;
+use function Saeghe\TestRunner\Assertions\Boolean\assert_true;
+
+test(
+    title: 'it should remove package using alias',
+    case: function () {
+        $output = shell_exec('php ' . root() . 'saeghe update datatype --project=TestRequirements/Fixtures/EmptyProject');
+        $expected = <<<EOD
+\e[39mUpdating package datatype to latest version...
+\e[39mSetting env credential...
+\e[39mLoading configs...
+\e[39mFinding package in configs...
+\e[39mSetting package version...
+\e[39mLoading package's config...
+\e[39mDeleting package's files...
+\e[39mDetecting version hash...
+\e[39mDownloading the package with new version...
+\e[39mUpdating configs...
+\e[39mCommitting new configs...
+\e[92mPackage git@github.com:saeghe/datatype.git has been updated.\e[39m
+
+EOD;
+
+        assert_true($expected === $output, 'Output is not correct:' . PHP_EOL . $expected . PHP_EOL . $output);
+        assert_true(file_exists(root() .  'TestRequirements/Fixtures/EmptyProject/Packages/saeghe/datatype'));
+        $config_file = root() . 'TestRequirements/Fixtures/EmptyProject/saeghe.config.json';
+        assert_false(
+            'v1.3.0'
+            ===
+            to_array($config_file)['packages']['git@github.com:saeghe/datatype.git']
+        );
+        $meta_file = root() . 'TestRequirements/Fixtures/EmptyProject/saeghe.config-lock.json';
+        assert_false(
+            'f527b3145dd30689075f5171566dfeee6809640b'
+            ===
+            to_array($meta_file)['packages']['git@github.com:saeghe/datatype.git']
+        );
+    },
+    before: function () {
+        shell_exec('php ' . root() . 'saeghe init --project=TestRequirements/Fixtures/EmptyProject');
+        shell_exec('php ' . root() . 'saeghe alias datatype git@github.com:saeghe/datatype.git --project=TestRequirements/Fixtures/EmptyProject');
+        shell_exec('php ' . root() . 'saeghe add datatype v1.3.0 --project=TestRequirements/Fixtures/EmptyProject');
+    },
+    after: function () {
+        clean(realpath(root() . 'TestRequirements/Fixtures/EmptyProject'));
+    }
+);

--- a/Tests/System/HelpCommandTest.php
+++ b/Tests/System/HelpCommandTest.php
@@ -16,7 +16,8 @@ start a working area
     migrate             Migrate from a composer project
 
 work with packages
-    credential          Add credential for given provider 
+    credential          Add credential for given provider
+    alias               Define an alias for a package 
     add                 Add a git repository as a package
     remove              Remove a git repository from packages
     update              Update the version of given package

--- a/Tests/System/ManCommandTest.php
+++ b/Tests/System/ManCommandTest.php
@@ -17,11 +17,15 @@ start a working area
                     `packages-directory` as an option. If passed, then your packages will be added under the given
                     directory instead of the default `Packages` directory.
     migrate  
-                    Migrate from a Composer project to a Saeghe project.
+                    Migrates from a Composer project to a Saeghe project.
 
 work with packages
     credential <provider> <token>
                     Add given `token` for the given `provider` in credential file.
+    alias <alias> <package>
+                    Defines the given alias as an alias for the given package. After defining an alias, you can use the
+                    alias in other commands where a package URL is required.
+
     add <package> {--version=}
                     Adds the given package to your project. This command needs a required `package` argument. You can 
                     pass an optional `version` option, then Saeghe will add the given version of the given package, 

--- a/Tests/System/RemoveCommand/RemovePackageWithMultipleDependenciesTest.php
+++ b/Tests/System/RemoveCommand/RemovePackageWithMultipleDependenciesTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\System\RemoveCommand\RemovePackageWithMultipleDependenciesTest;
+
+use function Saeghe\FileManager\Directory\clean;
+use function Saeghe\FileManager\Resolver\realpath;
+use function Saeghe\FileManager\Resolver\root;
+use function Saeghe\TestRunner\Assertions\Boolean\assert_false;
+use function Saeghe\TestRunner\Assertions\Boolean\assert_true;
+
+test(
+    title: 'it should remove package with multiple dependencies',
+    case: function () {
+        $output = shell_exec('php ' . root() . 'saeghe remove git@github.com:saeghe/datatype.git --project=TestRequirements/Fixtures/EmptyProject');
+        $expected = <<<EOD
+\e[39mRemoving package git@github.com:saeghe/datatype.git
+\e[39mLoading configs...
+\e[39mFinding package in configs...
+\e[39mLoading package's config...
+\e[39mRemoving package from config...
+\e[39mCommitting configs...
+\e[92mPackage git@github.com:saeghe/datatype.git has been removed successfully.\e[39m
+
+EOD;
+
+        assert_true($expected === $output, 'Output is not correct:' . PHP_EOL . $expected . PHP_EOL . $output);
+        assert_false(file_exists(root() .  'TestRequirements/Fixtures/EmptyProject/Packages/saeghe/datatype'));
+    },
+    before: function () {
+        shell_exec('php ' . root() . 'saeghe init --project=TestRequirements/Fixtures/EmptyProject');
+        shell_exec('php ' . root() . 'saeghe add git@github.com:saeghe/datatype.git --project=TestRequirements/Fixtures/EmptyProject');
+    },
+    after: function () {
+        clean(realpath(root() . 'TestRequirements/Fixtures/EmptyProject'));
+    }
+);

--- a/Tests/System/VersionCommandTest.php
+++ b/Tests/System/VersionCommandTest.php
@@ -10,7 +10,7 @@ test(
     case: function () {
         $output = shell_exec('php ' . root() . 'saeghe -v');
 
-        assert_success('Saeghe version 1.12.0', $output);
+        assert_success('Saeghe version 1.13.0', $output);
     }
 );
 
@@ -19,6 +19,6 @@ test(
     case: function () {
         $output = shell_exec('php ' . root() . 'saeghe --version');
 
-        assert_success('Saeghe version 1.12.0', $output);
+        assert_success('Saeghe version 1.13.0', $output);
     }
 );

--- a/saeghe
+++ b/saeghe
@@ -3,6 +3,7 @@
 
 require realpath(__DIR__ . '/Import.php');
 require realpath(__DIR__ . '/Source/Commands/Add.php');
+require realpath(__DIR__ . '/Source/Commands/Alias.php');
 require realpath(__DIR__ . '/Source/Commands/Build.php');
 require realpath(__DIR__ . '/Source/Commands/Credential.php');
 require realpath(__DIR__ . '/Source/Commands/Flush.php');
@@ -39,6 +40,7 @@ $environment = new Environment(Directory::from_string(__DIR__));
 
 match ($command) {
     'add' => \Saeghe\Saeghe\Commands\Add\run($environment),
+    'alias' => \Saeghe\Saeghe\Commands\Alias\run($environment),
     'build' => \Saeghe\Saeghe\Commands\Build\run($environment),
     'credential' => \Saeghe\Saeghe\Commands\Credential\run($environment),
     'flush' => \Saeghe\Saeghe\Commands\Flush\run($environment),
@@ -85,4 +87,9 @@ function unless(bool $condition, Closure $then, Closure $otherwise = null): mixe
 function pipe(mixed $value, Closure $closure): mixed
 {
     return is_callable($value) ? $closure($value()) : $closure($value);
+}
+
+function when_exists(mixed $value, Closure $then, Closure $otherwise = null): mixed
+{
+    return pipe($value, is_null($value) ? (is_null($otherwise) ? fn () => null : $otherwise) : $then);
 }


### PR DESCRIPTION
This PR adds an `alias` command. The alias command can get used to add an alias for a package and will be defined in the config file, therefore, it can be used in other commands where a package URL is required. 

example:

```shell
saeghe alias datatype git@github.com:saeghe/datatype
```
After that we can run the following:
```shell
saeghe add datatype
saeghe update datatype
saeghe remove datatype
```