### PR TITLE
Add the run command. Improve man and help output.

### DIFF
--- a/Source/Commands/Help.php
+++ b/Source/Commands/Help.php
@@ -28,6 +28,10 @@ work on an existing project
     build               Build the project
     watch               Watch file changes and build the project for each change
     flush               Flush files in build directory
+
+global access
+    run                 Run a project on the fly
+    version             Print current version number
 EOD;
 
     Write\line($content);

--- a/Source/Commands/Man.php
+++ b/Source/Commands/Man.php
@@ -27,19 +27,22 @@ work with packages
                     Defines the given alias as an alias for the given package. After defining an alias, you can use the
                     alias in other commands where a package URL is required.
 
-    add <package> {--version=}
-                    Adds the given package to your project. This command needs a required `package` argument. You can 
-                    pass an optional `version` option, then Saeghe will add the given version of the given package, 
+    add <package|alias> {--version=}
+                    Adds the given package to your project. This command needs a required `package` argument that should
+                    be a valid git URL (SSH or HTTPS) or a registered alias using the `alias` command.
+                    You can pass an optional `version` option, then Saeghe will add the given version of the given package, 
                     otherwise, it adds the latest released version on the package. The package’s source code will be 
                     added under your package’s directory, the package's path and installed version will be added to your
                      `saeghe.config.json` file and its metadata will be added to the `saeghe.config-lock.json` file.
-    remove <package>
-                    Removes the given package from your project. This command needs a required `package` argument. It 
-                    deleted given package's source files from your packages directory and also removes the package from
+    remove <package|alias>
+                    Removes the given package from your project. This command needs a required `package` argument that 
+                    should be a valid git URL (SSH or HTTPS) or a registered alias using the `alias` command. It deleted
+                    given package's source files from your packages directory and also removes the package from
                     `saeghe.config.json` and its metadata from `saeghe.config-lock.json`.
-    update <package> {--version=}
+    update <package|alias> {--version=}
                     If you need to get the latest version of an added package, you can run the update command. This 
-                    command needs a required `package` argument. You can also path an optional `version` option, if 
+                    command needs a required `package` argument that should be a valid git URL (SSH or HTTPS) or a 
+                    registered alias using the `alias` command. You can also path an optional `version` option, if 
                     passed, then Saeghe will download the exact version number, if not passed, it downloads the latest 
                     available version.
     install
@@ -56,6 +59,13 @@ work on an existing project
                     always builds files under the `development` environment.
     flush
                     If you need to delete any built files, running this command will give you a fresh `builds` directory.
+
+global access
+    run <package>
+                    Downloads, builds and runs the given package on the fly. You need to pass a valid git URL (SSH or HTTPS)
+                    to this command.
+    version
+                    Prints current version number.
 EOD;
 
     Write\line($content);

--- a/Source/Commands/Run.php
+++ b/Source/Commands/Run.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Saeghe\Saeghe\Commands\Run;
+
+use Saeghe\FileManager\Filesystem\Filename;
+use Saeghe\FileManager\FileType\Json;
+use Saeghe\FileManager\Filesystem\Directory;
+use Saeghe\Saeghe\Classes\Build\Build;
+use Saeghe\Saeghe\Classes\Config\Config;
+use Saeghe\Saeghe\Classes\Config\LinkPair;
+use Saeghe\Saeghe\Classes\Environment\Environment;
+use Saeghe\Saeghe\Classes\Meta\Dependency;
+use Saeghe\Saeghe\Classes\Meta\Meta;
+use Saeghe\Saeghe\Classes\Package\Package;
+use Saeghe\Saeghe\Classes\Project\Project;
+use Saeghe\Saeghe\Git\Repository;
+use function Saeghe\Cli\IO\Read\argument;
+use function Saeghe\Cli\IO\Write\error;
+use function Saeghe\Saeghe\Commands\Build\add_autoloads;
+use function Saeghe\Saeghe\Commands\Build\add_executables;
+use function Saeghe\Saeghe\Commands\Build\compile_packages;
+use function Saeghe\Saeghe\Commands\Build\compile_project_files;
+
+function run(Environment $environment): void
+{
+    $package_url = argument(2);
+
+    set_credentials($environment);
+
+    $repository = Repository::from_url($package_url)->latest_version()->detect_hash();
+
+    $root = Directory::from_string(sys_get_temp_dir())->subdirectory('saeghe/runner/' . $repository->owner . '/' . $repository->repo);
+
+    if (! $repository->file_exists('saeghe.config.json')) {
+        error("Given $package_url URL is not a Saeghe package.");
+        return;
+    }
+
+    $repository->download($root);
+
+    $project = new Project($root);
+
+    $project->config(Config::from_array(Json\to_array($project->config_file)));
+    $project->meta = Meta::from_array(Json\to_array($project->meta_file));
+
+    $project->packages_directory->exists_or_create();
+
+    $project->meta->dependencies->each(function (Dependency $dependency) use ($project) {
+        $package = new Package($project->package_directory($dependency->repository()), $dependency->repository());
+        $package->download();
+    });
+
+    $build = new Build($project, 'production');
+    $build->root()->renew_recursive();
+    $build->packages_directory()->exists_or_create();
+    $build->load_namespace_map();
+
+    $project->packages->each(function (Package $package) use ($project, $build) {
+        compile_packages($package, $build);
+    });
+
+    compile_project_files($build);
+
+    $project->config->entry_points->each(function (Filename $entry_point) use ($build) {
+        add_autoloads($build, $build->root()->file($entry_point));
+    });
+
+    $project->packages->each(function (Package $package)  use ($project, $build) {
+        $package->config->executables->each(function (LinkPair $executable) use ($build, $package) {
+            add_executables($build, $build->package_root($package)->file($executable->source()), $build->root()->symlink($executable->symlink()));
+        });
+    });
+
+    $entry_point = argument(3) ? argument(3) : $project->config->entry_points->first();
+
+    $entry_point_path = $build->root()->file($entry_point)->path;
+
+    if (! $entry_point_path->exists()) {
+        error("Entry point $entry_point is not defined in the package.");
+        return;
+    }
+
+    include_once $entry_point_path->string();
+}

--- a/Source/Commands/Version.php
+++ b/Source/Commands/Version.php
@@ -6,5 +6,5 @@ use Saeghe\Cli\IO\Write;
 
 function run(): void
 {
-    Write\success('Saeghe version 1.13.0');
+    Write\success('Saeghe version 1.14.0');
 }

--- a/Source/Git/GitHub.php
+++ b/Source/Git/GitHub.php
@@ -8,6 +8,7 @@ use function Saeghe\FileManager\Directory\ls;
 use function Saeghe\FileManager\Directory\preserve_copy_recursively;
 use function Saeghe\FileManager\Directory\renew_recursive;
 use function Saeghe\FileManager\File\delete;
+use function Saeghe\FileManager\Resolver\realpath;
 
 const GITHUB_DOMAIN = 'github.com';
 const GITHUB_URL = 'https://github.com/';
@@ -112,7 +113,8 @@ function find_latest_commit_hash(string $owner, string $repo): string
 function download(string $destination, string $owner, string $repo, string $version): bool
 {
     $token = github_token();
-    $temp = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $owner . DIRECTORY_SEPARATOR;
+    $temp = realpath(sys_get_temp_dir(). "/saeghe/installer/cache/$owner/$repo/") . DIRECTORY_SEPARATOR;
+
     renew_recursive($temp);
 
     $zip_file = $temp . $repo . '.zip';

--- a/Tests/Git/GitHubTest.php
+++ b/Tests/Git/GitHubTest.php
@@ -122,7 +122,7 @@ test(
             ),
             'config file does not found'
         );
-        assert_false(\file_exists(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'saeghe' . DIRECTORY_SEPARATOR . 'released-package.zip'), 'zip file is not deleted');
+        assert_false(\file_exists(realpath(sys_get_temp_dir(). '/saeghe/installer/cache/saeghe/released-package.zip/')), 'zip file is not deleted');
 
         return $packages_directory;
     },

--- a/Tests/System/HelpCommandTest.php
+++ b/Tests/System/HelpCommandTest.php
@@ -27,6 +27,10 @@ work on an existing project
     build               Build the project
     watch               Watch file changes and build the project for each change
     flush               Flush files in build directory
+
+global access
+    run                 Run a project on the fly
+    version             Print current version number
 EOD;
 
 test(

--- a/Tests/System/ManCommandTest.php
+++ b/Tests/System/ManCommandTest.php
@@ -26,19 +26,22 @@ work with packages
                     Defines the given alias as an alias for the given package. After defining an alias, you can use the
                     alias in other commands where a package URL is required.
 
-    add <package> {--version=}
-                    Adds the given package to your project. This command needs a required `package` argument. You can 
-                    pass an optional `version` option, then Saeghe will add the given version of the given package, 
+    add <package|alias> {--version=}
+                    Adds the given package to your project. This command needs a required `package` argument that should
+                    be a valid git URL (SSH or HTTPS) or a registered alias using the `alias` command.
+                    You can pass an optional `version` option, then Saeghe will add the given version of the given package, 
                     otherwise, it adds the latest released version on the package. The package’s source code will be 
                     added under your package’s directory, the package's path and installed version will be added to your
                      `saeghe.config.json` file and its metadata will be added to the `saeghe.config-lock.json` file.
-    remove <package>
-                    Removes the given package from your project. This command needs a required `package` argument. It 
-                    deleted given package's source files from your packages directory and also removes the package from
+    remove <package|alias>
+                    Removes the given package from your project. This command needs a required `package` argument that 
+                    should be a valid git URL (SSH or HTTPS) or a registered alias using the `alias` command. It deleted
+                    given package's source files from your packages directory and also removes the package from
                     `saeghe.config.json` and its metadata from `saeghe.config-lock.json`.
-    update <package> {--version=}
+    update <package|alias> {--version=}
                     If you need to get the latest version of an added package, you can run the update command. This 
-                    command needs a required `package` argument. You can also path an optional `version` option, if 
+                    command needs a required `package` argument that should be a valid git URL (SSH or HTTPS) or a 
+                    registered alias using the `alias` command. You can also path an optional `version` option, if 
                     passed, then Saeghe will download the exact version number, if not passed, it downloads the latest 
                     available version.
     install
@@ -55,6 +58,13 @@ work on an existing project
                     always builds files under the `development` environment.
     flush
                     If you need to delete any built files, running this command will give you a fresh `builds` directory.
+
+global access
+    run <package>
+                    Downloads, builds and runs the given package on the fly. You need to pass a valid git URL (SSH or HTTPS)
+                    to this command.
+    version
+                    Prints current version number.
 EOD;
 
 

--- a/Tests/System/RunCommand/RunCommandTest.php
+++ b/Tests/System/RunCommand/RunCommandTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\System\RunCommand\RunCommandTest;
+
+use function Saeghe\FileManager\Resolver\root;
+use function Saeghe\TestRunner\Assertions\Boolean\assert_true;
+
+test(
+    title: 'it should run the given entry point on the given package',
+    case: function () {
+        $output = shell_exec('php ' . root() . 'saeghe run https://github.com/saeghe/chuck-norris.git');
+
+        assert_true(str_contains($output, 'Chuck Norris'));
+    }
+);
+
+test(
+    title: 'it should show error message when the package is not a Saeghe package',
+    case: function () {
+        $output = shell_exec('php ' . root() . 'saeghe run https://github.com/symfony/thanks.git');
+
+        $expected = <<<EOD
+\e[91mGiven https://github.com/symfony/thanks.git URL is not a Saeghe package.\e[39m
+
+EOD;
+
+        assert_true($expected === $output, 'Output is not correct:' . PHP_EOL . $expected . PHP_EOL . $output);
+    }
+);
+
+test(
+    title: 'it should show error message when the entry point is not defined',
+    case: function () {
+        $output = shell_exec('php ' . root() . 'saeghe run https://github.com/saeghe/chuck-norris.git not-exists.php');
+
+        $expected = <<<EOD
+\e[91mEntry point not-exists.php is not defined in the package.\e[39m
+
+EOD;
+
+        assert_true($expected === $output, 'Output is not correct:' . PHP_EOL . $expected . PHP_EOL . $output);
+    }
+);

--- a/Tests/System/VersionCommandTest.php
+++ b/Tests/System/VersionCommandTest.php
@@ -10,7 +10,7 @@ test(
     case: function () {
         $output = shell_exec('php ' . root() . 'saeghe -v');
 
-        assert_success('Saeghe version 1.13.0', $output);
+        assert_success('Saeghe version 1.14.0', $output);
     }
 );
 
@@ -19,6 +19,6 @@ test(
     case: function () {
         $output = shell_exec('php ' . root() . 'saeghe --version');
 
-        assert_success('Saeghe version 1.13.0', $output);
+        assert_success('Saeghe version 1.14.0', $output);
     }
 );

--- a/saeghe
+++ b/saeghe
@@ -13,6 +13,7 @@ require realpath(__DIR__ . '/Source/Commands/Install.php');
 require realpath(__DIR__ . '/Source/Commands/Man.php');
 require realpath(__DIR__ . '/Source/Commands/Migrate.php');
 require realpath(__DIR__ . '/Source/Commands/Remove.php');
+require realpath(__DIR__ . '/Source/Commands/Run.php');
 require realpath(__DIR__ . '/Source/Commands/Update.php');
 require realpath(__DIR__ . '/Source/Commands/Version.php');
 require realpath(__DIR__ . '/Source/Commands/Watch.php');
@@ -49,6 +50,7 @@ match ($command) {
     'man' => \Saeghe\Saeghe\Commands\Man\run(),
     'migrate' => \Saeghe\Saeghe\Commands\Migrate\run($environment),
     'remove' => \Saeghe\Saeghe\Commands\Remove\run($environment),
+    'run' => \Saeghe\Saeghe\Commands\Run\run($environment),
     'update' => \Saeghe\Saeghe\Commands\Update\run($environment),
     'version' => \Saeghe\Saeghe\Commands\Version\run(),
     'watch' => \Saeghe\Saeghe\Commands\Watch\run(),


### PR DESCRIPTION
Add a `run` command to download, install, build and run Saeghe packages on the fly.
